### PR TITLE
Run PEP8 on content

### DIFF
--- a/authentication_sample.py
+++ b/authentication_sample.py
@@ -45,11 +45,13 @@ class AuthenticationSample(KeyVaultSampleBase):
 
         # set and get a secret from the vault to validate the client is authenticated
         print('creating secret...')
-        secret_bundle = client.set_secret(vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
+        secret_bundle = client.set_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
         print(secret_bundle)
 
         print('getting secret...')
-        secret_bundle = client.get_secret(vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
+        secret_bundle = client.get_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
         print(secret_bundle)
 
     @keyvaultsample
@@ -63,7 +65,8 @@ class AuthenticationSample(KeyVaultSampleBase):
         import adal
 
         # create an adal authentication context
-        auth_context = adal.AuthenticationContext('https://login.microsoftonline.com/%s' % self.config.tenant_id)
+        auth_context = adal.AuthenticationContext(
+            'https://login.microsoftonline.com/%s' % self.config.tenant_id)
 
         # create a callback to supply the token type and access token on request
         def adal_callback(server, resource, scope):
@@ -80,11 +83,13 @@ class AuthenticationSample(KeyVaultSampleBase):
 
         # set and get a secret from the vault to validate the client is authenticated
         print('creating secret...')
-        secret_bundle = client.set_secret(vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
+        secret_bundle = client.set_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
         print(secret_bundle)
 
         print('getting secret...')
-        secret_bundle = client.get_secret(vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
+        secret_bundle = client.get_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
         print(secret_bundle)
 
     @keyvaultsample
@@ -98,7 +103,8 @@ class AuthenticationSample(KeyVaultSampleBase):
         import adal
 
         # create an adal authentication context
-        auth_context = adal.AuthenticationContext('https://login.microsoftonline.com/%s' % self.config.tenant_id)
+        auth_context = adal.AuthenticationContext(
+            'https://login.microsoftonline.com/%s' % self.config.tenant_id)
 
         # using the XPlat command line client id as it is available across all tenants and subscriptions
         # this would be replaced by your app id
@@ -123,11 +129,13 @@ class AuthenticationSample(KeyVaultSampleBase):
 
         # set and get a secret from the vault to validate the client is authenticated
         print('creating secret...')
-        secret_bundle = client.set_secret(vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
+        secret_bundle = client.set_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', 'client is authenticated to the vault')
         print(secret_bundle)
 
         print('getting secret...')
-        secret_bundle = client.get_secret(vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
+        secret_bundle = client.get_secret(
+            vault.properties.vault_uri, 'auth-sample-secret', secret_version=KeyVaultId.version_none)
         print(secret_bundle)
 
 

--- a/key_vault_sample_config.py
+++ b/key_vault_sample_config.py
@@ -14,7 +14,7 @@ class KeyVaultSampleConfig(object):
 
     :ivar subscription_id: Azure subscription id for the user intending to run the sample
     :vartype subscription_id: str
-    
+
     :ivar client_id: Azure Active Directory AppID of the Service Principle to run the sample
     :vartype client_id: str
 
@@ -26,20 +26,26 @@ class KeyVaultSampleConfig(object):
 
     :ivar client_secret: Azure Active Directory Application Key to run the sample
     :vartype client_secret: str
-    
+
     :ivar location: Azure regional location on which to execute the sample 
     :vartype location: str
-    
+
     :ivar group_name: Azure resource group on which to execute the sample 
     :vartype group_name: str
     """
 
     def __init__(self):
         # get credential information from the environment or replace the dummy values with your client credentials
-        self.subscription_id = os.getenv('AZURE_SUBSCRIPTION_ID', '11111111-1111-1111-1111-111111111111')
-        self.client_id = os.getenv('AZURE_CLIENT_ID', '22222222-2222-2222-2222-222222222222')
-        self.client_oid = os.getenv('AZURE_CLIENT_OID', '33333333-3333-3333-3333-333333333333')
-        self.tenant_id = os.getenv('AZURE_TENANT_ID', '44444444-4444-4444-4444-444444444444')
-        self.client_secret = os.getenv('AZURE_CLIENT_SECRET', 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=')
+        self.subscription_id = os.getenv(
+            'AZURE_SUBSCRIPTION_ID', '11111111-1111-1111-1111-111111111111')
+        self.client_id = os.getenv(
+            'AZURE_CLIENT_ID', '22222222-2222-2222-2222-222222222222')
+        self.client_oid = os.getenv(
+            'AZURE_CLIENT_OID', '33333333-3333-3333-3333-333333333333')
+        self.tenant_id = os.getenv(
+            'AZURE_TENANT_ID', '44444444-4444-4444-4444-444444444444')
+        self.client_secret = os.getenv(
+            'AZURE_CLIENT_SECRET', 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=')
         self.location = os.getenv('AZURE_LOCATION', 'westus')
-        self.group_name = os.getenv('AZURE_RESOURCE_GROUP', 'azure-key-vault-samples')
+        self.group_name = os.getenv(
+            'AZURE_RESOURCE_GROUP', 'azure-key-vault-samples')

--- a/run_all_samples.py
+++ b/run_all_samples.py
@@ -6,13 +6,20 @@ from key_vault_sample_config import KeyVaultSampleConfig
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--ci', default=False, action='store_true', help='indicates that only samples which run as part of the ci should be run')
-    parser.add_argument('--tenant-id', dest='tenant_id', type=str, default=None, help='the tenant id of the tenant in which to run the sample')
-    parser.add_argument('--subscription-id', dest='subscription_id', type=str, default=None, help='the subscription id of the subscription in which to run the sample')
-    parser.add_argument('--client-id', dest='client_id', type=str, default=None, help='the client id of the service principal to run the sample')
-    parser.add_argument('--client-oid', dest='client_oid', type=str, default=None, help='the object id of the service principal to run the sample')
-    parser.add_argument('--client-secret', dest='client_secret', type=str, default=None, help='the authentication secret of the service principal to run the sample')
-    parser.add_argument('--samples', nargs='*', type=str, help='names of specific samples to run')
+    parser.add_argument('--ci', default=False, action='store_true',
+                        help='indicates that only samples which run as part of the ci should be run')
+    parser.add_argument('--tenant-id', dest='tenant_id', type=str, default=None,
+                        help='the tenant id of the tenant in which to run the sample')
+    parser.add_argument('--subscription-id', dest='subscription_id', type=str, default=None,
+                        help='the subscription id of the subscription in which to run the sample')
+    parser.add_argument('--client-id', dest='client_id', type=str, default=None,
+                        help='the client id of the service principal to run the sample')
+    parser.add_argument('--client-oid', dest='client_oid', type=str, default=None,
+                        help='the object id of the service principal to run the sample')
+    parser.add_argument('--client-secret', dest='client_secret', type=str, default=None,
+                        help='the authentication secret of the service principal to run the sample')
+    parser.add_argument('--samples', nargs='*', type=str,
+                        help='names of specific samples to run')
     args = parser.parse_args()
 
     config = KeyVaultSampleConfig()
@@ -28,4 +35,5 @@ if __name__ == "__main__":
     if args.client_secret:
         config.client_secret = args.client_secret
 
-    run_all_samples([AuthenticationSample(config=config)], requested=args.samples or [])
+    run_all_samples([AuthenticationSample(config=config)],
+                    requested=args.samples or [])


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.